### PR TITLE
Move search items from inline script to data attribute

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -23,7 +23,7 @@ const noteItems = sortedNotes.map((note) => ({
 const searchItems = [...pages, ...noteItems];
 ---
 
-<div id="command-palette" class="palette-backdrop" aria-modal="true" role="dialog" aria-label="Command palette">
+<div id="command-palette" class="palette-backdrop" aria-modal="true" role="dialog" aria-label="Command palette" data-search-items={JSON.stringify(searchItems)}>
   <div class="palette-modal">
     <div class="palette-input-row">
       <span class="palette-label">⌘K</span>
@@ -44,11 +44,9 @@ const searchItems = [...pages, ...noteItems];
   </div>
 </div>
 
-<script is:inline set:html={`window.__SEARCH_ITEMS__ = ${JSON.stringify(searchItems)};`} />
-
 <script>
-  const items = (window as any).__SEARCH_ITEMS__;
   const backdrop = document.getElementById("command-palette")!;
+  const items = JSON.parse(backdrop.dataset.searchItems!);
   const input = document.getElementById("palette-input")! as HTMLInputElement;
   const resultsContainer = document.getElementById("palette-results")!;
   let highlightIndex = 0;

--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -47,7 +47,7 @@ const searchItems = [...pages, ...noteItems];
 <script is:inline set:html={`window.__SEARCH_ITEMS__ = ${JSON.stringify(searchItems)};`} />
 
 <script>
-  const items = window.__SEARCH_ITEMS__;
+  const items = (window as any).__SEARCH_ITEMS__;
   const backdrop = document.getElementById("command-palette")!;
   const input = document.getElementById("palette-input")! as HTMLInputElement;
   const resultsContainer = document.getElementById("palette-results")!;


### PR DESCRIPTION
## Summary
Refactored the CommandPalette component to pass search items via a data attribute instead of using an inline script that sets a global variable.

## Key Changes
- Moved `searchItems` from an inline `<script>` tag that set `window.__SEARCH_ITEMS__` to a `data-search-items` attribute on the command palette container
- Updated the client-side script to parse the search items from the data attribute instead of accessing the global variable
- Removed the separate inline script block that was previously used to expose search items globally

## Implementation Details
- Search items are serialized as JSON in the `data-search-items` attribute during component render
- The client script retrieves and parses the data attribute using `JSON.parse(backdrop.dataset.searchItems)`
- This approach eliminates the need for global variable pollution and keeps data scoped to the component element

https://claude.ai/code/session_01ToW7JH6rZnZM56NqpBue6a